### PR TITLE
Feat: implement pre-upgrade and post-upgrage hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,8 @@ dependencies = [
  "ic-cdk-macros",
  "ic-cdk-timers",
  "lazy_static",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -335,6 +337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +458,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "serde"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +490,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/src/Futura_backend/Cargo.toml
+++ b/src/Futura_backend/Cargo.toml
@@ -13,6 +13,8 @@ candid = "0.10"
 ic-cdk = "0.16"
 ic-cdk-macros = "0.16.0"
 lazy_static = "1.4"
+serde = { version = "1.0.210", features = ["derive"] } 
+serde_json = "1.0.128" 
 
 
 


### PR DESCRIPTION
Before dfx deploy, you need to run `cargo build` and `dfx canister install --mode=reinstall futura_backend`. This will reset the memory in the canister and we will lose the data. This is cause the format somehow changed now. 